### PR TITLE
secondary compartment/context assignment

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,7 +15,7 @@ on:
       - '.gitignore'
   pull_request:
     branches: [master, develop]
-    types: [opened, reopened]   # excludes syncronize to avoid redundant trigger from commits on PRs
+    types: [opened, reopened, ready_for_review]   # excludes syncronize to avoid redundant trigger from commits on PRs
     paths-ignore:
       - '**.md'
       - '**.bib'

--- a/README.md
+++ b/README.md
@@ -130,6 +130,9 @@ or
 pip install . -r requirements.txt -r rcrainfo_requirements.txt
 ```
 
+### Secondary Context Installation Steps
+In order to enable calculation and assignment of urban/rural and release height secondary contexts, please refer to [esupy's README.md](https://github.com/USEPA/esupy/tree/main#installation-instructions-for-optional-geospatial-packages) for installation instructions, which may require a copy of the [`env_sec_ctxt.yaml`](https://github.com/USEPA/standardizedinventories/blob/master/env_sec_ctxt.yaml) file included here.
+
 
 ## Wiki
 

--- a/README.md
+++ b/README.md
@@ -131,13 +131,12 @@ pip install . -r requirements.txt -r rcrainfo_requirements.txt
 ```
 
 ### Secondary Context Installation Steps
-In order to enable calculation and assignment of urban/rural and release height secondary contexts, please refer to [esupy's README.md](https://github.com/USEPA/esupy/tree/main#installation-instructions-for-optional-geospatial-packages) for installation instructions, which may require a copy of the [`env_sec_ctxt.yaml`](https://github.com/USEPA/standardizedinventories/blob/master/env_sec_ctxt.yaml) file included here.
+In order to enable calculation and assignment of urban/rural secondary contexts, please refer to [esupy's README.md](https://github.com/USEPA/esupy/tree/main#installation-instructions-for-optional-geospatial-packages) for installation instructions, which may require a copy of the [`env_sec_ctxt.yaml`](https://github.com/USEPA/standardizedinventories/blob/master/env_sec_ctxt.yaml) file included here.
 
 
 ## Wiki
 
-See the [Wiki](https://github.com/USEPA/standardizedinventories/wiki) for instructions on installation and use and for
-contact information.
+See the [Wiki](https://github.com/USEPA/standardizedinventories/wiki) for instructions on installation and use and for contact information.
 
 ## Disclaimer
 

--- a/env_sec_ctxt.yaml
+++ b/env_sec_ctxt.yaml
@@ -17,6 +17,3 @@ dependencies:
         - pyarrow==6.0.1  # causes error if installed via conda default channel "OSError: NotImplemented: Support for codec 'snappy' not built"
         - requests_ftp==0.3.1        
         - "--editable=git+https://github.com/USEPA/standardizedinventories.git@urban_rural_classify#egg=StEWI"
-        
-        # - "--editable=git+https://github.com/USEPA/esupy.git@urban_rural_classify#egg=esupy"
-          # Note: uncommenting above line causes pip conflict despite character-for-character identical VCS urls

--- a/env_sec_ctxt.yaml
+++ b/env_sec_ctxt.yaml
@@ -1,0 +1,22 @@
+name: stewi_2ndry_ctxt
+channels:
+    - defaults
+dependencies:
+    - python=3.9.7          
+    - pip=21.2.4       # must specify else conda returns warning
+    - numpy=1.21.2
+    - pandas=1.3.4          
+    - geopandas=0.9.0
+    - shapely=1.7.1
+    - requests=2.26.0
+    - appdirs=1.4.4
+    #- pytest=6.2.4
+    - spyder
+
+    - pip:
+        - pyarrow==6.0.1  # causes error if installed via conda default channel "OSError: NotImplemented: Support for codec 'snappy' not built"
+        - requests_ftp==0.3.1        
+        - "--editable=git+https://github.com/USEPA/standardizedinventories.git@urban_rural_classify#egg=StEWI"
+        
+        # - "--editable=git+https://github.com/USEPA/esupy.git@urban_rural_classify#egg=esupy"
+          # Note: uncommenting above line causes pip conflict despite character-for-character identical VCS urls

--- a/format specs/Facility.md
+++ b/format specs/Facility.md
@@ -13,7 +13,9 @@ Longitude |Numeric|N|Longitude in decimal degrees|
 County |String|N|County Name|
 NAICS |String|N|[NAICS code](https://www.census.gov/cgi-bin/sssd/naics/naicsrch?chart=2012), NAICS 2012 is assumed.|
 SIC |String|N|[Standard Industry Classification (1987)](https://www.osha.gov/pls/imis/sicsearch.html)|
+UrbanRural | String | N | Population density of the facility*: `urban`, `rural`, or `unspecified`
 
 Additional fields specific to individual inventories are maintained in some cases.
 - eGRID [facility fields](https://github.com/USEPA/standardizedinventories/blob/master/stewi/data/eGRID/eGRID_required_fields.csv)
 
+* Optionally assigned by esupy if [geospatial packages are installed](https://github.com/USEPA/standardizedinventories#secondary-context-installation-steps).

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-install_requires=['esupy @ git+https://github.com/USEPA/esupy.git@develop#egg=esupy',
+install_requires=['esupy @ git+https://github.com/USEPA/esupy.git@urban_rural_classify#egg=esupy',
                   'numpy>=1.20.1',
                   'pandas>=1.3',
                   'requests>=2.20',

--- a/stewi/NEI.py
+++ b/stewi/NEI.py
@@ -280,9 +280,11 @@ def main(**kwargs):
             #2011: 277
 
             log.info('generating facility output')
-            facility = nei_point[['FacilityID', 'FacilityName', 'Address',
-                                  'City', 'State', 'Zip', 'Latitude',
-                                  'Longitude', 'NAICS', 'County', 'cmpt_urb']]
+            fac_fields = ['FacilityID', 'FacilityName', 'Address',
+                          'City', 'State', 'Zip', 'Latitude',
+                          'Longitude', 'NAICS', 'County', 'cmpt_urb']
+            facility = nei_point[[f for f in fac_fields
+                                  if f in nei_point.columns]]
             facility = facility.drop_duplicates('FacilityID')
             facility = facility.astype({'Zip': 'str'})
             store_inventory(facility, 'NEI_' + year, 'facility')

--- a/stewi/NEI.py
+++ b/stewi/NEI.py
@@ -112,15 +112,6 @@ def standardize_output(year, source='Point'):
                                 'ReliabilityScore'])
 
         nei['Compartment'] = 'air'
-        """
-        # Modify compartment based on stack height (ft)
-        nei.loc[nei['StackHeight'] < 32, 'Compartment'] = 'air/ground'
-        nei.loc[(nei['StackHeight'] >= 32) & (nei['StackHeight'] < 164),
-                'Compartment'] = 'air/low'
-        nei.loc[(nei['StackHeight'] >= 164) & (nei['StackHeight'] < 492),
-                'Compartment'] = 'air/high'
-        nei.loc[nei['StackHeight'] >= 492, 'Compartment'] = 'air/very high'
-        """
     else:
         nei['DataReliability'] = 3
     # add Source column

--- a/stewi/NEI.py
+++ b/stewi/NEI.py
@@ -45,6 +45,7 @@ from stewi.globals import DATA_PATH, write_metadata, USton_kg, lb_kg,\
     assign_secondary_context
 from stewi.validate import update_validationsets_sources, validate_inventory,\
     write_validation_result
+from stewi.formats import facility_fields
 
 
 _config = config()['databases']['NEI']
@@ -212,15 +213,15 @@ def validate_national_totals(nei_flowbyfacility, year):
     write_validation_result('NEI', year, validation_result)
 
 
-def generate_metadata(year, datatype='inventory'):
+def generate_metadata(year, parameters):
     """Get metadata and writes to .json."""
     nei_file_path = _config[year]['file_name']
-    if datatype == 'inventory':
-        source_meta = []
-        for file in nei_file_path:
-            meta = set_stewi_meta(strip_file_extension(file), EXT_DIR)
-            source_meta.append(read_source_metadata(paths, meta, force_JSON=True))
-        write_metadata('NEI_' + year, source_meta, datatype=datatype)
+    source_meta = []
+    for file in nei_file_path:
+        meta = set_stewi_meta(strip_file_extension(file), EXT_DIR)
+        source_meta.append(read_source_metadata(paths, meta, force_JSON=True))
+    write_metadata(f'NEI_{year}', source_meta, datatype='inventory',
+                   parameters=parameters)
 
 
 def main(**kwargs):
@@ -246,13 +247,13 @@ def main(**kwargs):
         if kwargs['Option'] == 'A':
 
             nei_point = standardize_output(year)
-            nei_point = assign_secondary_context(nei_point, int(year),
-                                                 'urb', 'rh', 'concat')
+            nei_point, parameters = (assign_secondary_context(
+                nei_point, int(year), 'urb', 'rh', 'concat'))
 
             log.info('generating flow by facility output')
             nei_flowbyfacility = aggregate(nei_point, ['FacilityID', 'FlowName',
                                                        'Compartment'])
-            store_inventory(nei_flowbyfacility, 'NEI_' + year, 'flowbyfacility')
+            store_inventory(nei_flowbyfacility, f'NEI_{year}', 'flowbyfacility')
             log.debug(len(nei_flowbyfacility))
             #2017: 2184786
             #2016: 1965918
@@ -263,7 +264,7 @@ def main(**kwargs):
             nei_flowbyprocess = aggregate(nei_point, ['FacilityID', 'Compartment',
                                                       'FlowName', 'Process'])
             nei_flowbyprocess['ProcessType'] = 'SCC'
-            store_inventory(nei_flowbyprocess, 'NEI_' + year, 'flowbyprocess')
+            store_inventory(nei_flowbyprocess, f'NEI_{year}', 'flowbyprocess')
             log.debug(len(nei_flowbyprocess))
             #2017: 4055707
 
@@ -272,7 +273,7 @@ def main(**kwargs):
             nei_flows = nei_flows.drop_duplicates()
             nei_flows['Unit'] = 'kg'
             nei_flows = nei_flows.sort_values(by='FlowName', axis=0)
-            store_inventory(nei_flows, 'NEI_' + year, 'flow')
+            store_inventory(nei_flows, f'NEI_{year}', 'flow')
             log.debug(len(nei_flows))
             #2017: 293
             #2016: 282
@@ -280,21 +281,18 @@ def main(**kwargs):
             #2011: 277
 
             log.info('generating facility output')
-            fac_fields = ['FacilityID', 'FacilityName', 'Address',
-                          'City', 'State', 'Zip', 'Latitude',
-                          'Longitude', 'NAICS', 'County', 'UrbanRural']
-            facility = nei_point[[f for f in fac_fields
+            facility = nei_point[[f for f in facility_fields
                                   if f in nei_point.columns]]
             facility = facility.drop_duplicates('FacilityID')
             facility = facility.astype({'Zip': 'str'})
-            store_inventory(facility, 'NEI_' + year, 'facility')
+            store_inventory(facility, f'NEI_{year}', 'facility')
             log.debug(len(facility))
             #2017: 87162
             #2016: 85802
             #2014: 85125
             #2011: 95565
 
-            generate_metadata(year, datatype='inventory')
+            generate_metadata(year, parameters)
 
             if year in ['2011', '2014', '2017']:
                 validate_national_totals(nei_flowbyfacility, year)

--- a/stewi/NEI.py
+++ b/stewi/NEI.py
@@ -282,7 +282,7 @@ def main(**kwargs):
             log.info('generating facility output')
             fac_fields = ['FacilityID', 'FacilityName', 'Address',
                           'City', 'State', 'Zip', 'Latitude',
-                          'Longitude', 'NAICS', 'County', 'cmpt_urb']
+                          'Longitude', 'NAICS', 'County', 'UrbanRural']
             facility = nei_point[[f for f in fac_fields
                                   if f in nei_point.columns]]
             facility = facility.drop_duplicates('FacilityID')

--- a/stewi/NEI.py
+++ b/stewi/NEI.py
@@ -256,7 +256,7 @@ def main(**kwargs):
 
             nei_point = standardize_output(year)
             nei_point = assign_secondary_context(nei_point, int(year),
-                                                 'urb', 'rh')
+                                                 'urb', 'rh', 'concat')
 
             log.info('generating flow by facility output')
             nei_flowbyfacility = aggregate(nei_point, ['FacilityID', 'FlowName',

--- a/stewi/TRI.py
+++ b/stewi/TRI.py
@@ -37,7 +37,7 @@ from pathlib import Path
 from stewi.globals import unit_convert, DATA_PATH, set_stewi_meta,\
     get_reliability_table_for_source, write_metadata, url_is_alive,\
     lb_kg, g_kg, config, store_inventory, log, paths, compile_source_metadata,\
-    read_source_metadata, aggregate
+    read_source_metadata, aggregate, assign_secondary_context, concat_compartment
 from stewi.validate import update_validationsets_sources, validate_inventory,\
     write_validation_result
 import stewi.exceptions
@@ -95,8 +95,7 @@ def generate_national_totals(year):
     """
     filename = TRI_DATA_PATH.joinpath(f'TRI_chem_release_{year}.csv')
     df = pd.read_csv(filename, header=0)
-    df.replace(',', 0.0, inplace=True)
-    df.replace('.', 0.0, inplace=True)
+    df = df.replace(',', 0.0).replace('.', 0.0)
     cols = ['Compartment', 'FlowName', 'Unit', 'FlowAmount']
     compartments = {'air': ['Fugitive Air Emissions',
                             'Point Source Air Emissions'],
@@ -114,7 +113,7 @@ def generate_national_totals(year):
         for column in columns:
             df_aux[column] = df_aux[column].str.replace(',', '').astype('float')
         df_aux['FlowAmount'] = df_aux[columns].sum(axis=1)
-        df_aux.rename(columns={'Chemical': 'FlowName'}, inplace=True)
+        df_aux = df_aux.rename(columns={'Chemical': 'FlowName'})
         df_aux['Unit'] = 'Pounds'
         df_aux['Compartment'] = compartment
         df_National = pd.concat([df_National, df_aux], axis=0,
@@ -128,7 +127,7 @@ def generate_national_totals(year):
     if df_National is None:
         log.warning('Totals not generated')
         return
-    df_National.sort_values(by=['FlowName', 'Compartment'], inplace=True)
+    df_National = df_National.sort_values(by=['FlowName', 'Compartment'])
     log.info(f'saving TRI_{year}_NationalTotals.csv to {DATA_PATH}')
     df_National.to_csv(DATA_PATH.joinpath(f'TRI_{year}_NationalTotals.csv'),
                        index=False)
@@ -179,10 +178,11 @@ def map_to_fedefl(df):
     return mapped_df
 
 
-def imp_fields(tri_fields_txt):
-    """Import list of fields from TRI that are desired for LCI."""
-    tri_required_fields_csv = tri_fields_txt
-    tri_req_fields = pd.read_csv(tri_required_fields_csv, header=None)
+def imp_fields(fname):
+    """
+    Import list of fields from TRI that are desired for LCI.
+    """
+    tri_req_fields = pd.read_csv(fname, header=None)
     tri_req_fields = list(tri_req_fields[0])
     return tri_req_fields
 
@@ -233,12 +233,6 @@ def import_TRI_by_release_type(d, year):
     return tri
 
 
-def strip_coln_white_space(df, coln):
-    """Remove white space after some basis of estimate codes."""
-    df[coln] = df[coln].str.strip()
-    return df
-
-
 def validate_national_totals(inv, TRIyear):
     log.info('validating data against national totals')
     filename = DATA_PATH.joinpath(f'TRI_{TRIyear}_NationalTotals.csv')
@@ -248,12 +242,10 @@ def validate_national_totals(inv, TRIyear):
         tri_national_totals['FlowAmount_kg'] = 0
         tri_national_totals = unit_convert(tri_national_totals, 'FlowAmount_kg',
                                            'Unit', 'Pounds', lb_kg, 'FlowAmount')
-        # drop old amount and units
-        tri_national_totals.drop('FlowAmount', axis=1, inplace=True)
-        tri_national_totals.drop('Unit', axis=1, inplace=True)
-        # Rename cols to match reference format
-        tri_national_totals.rename(columns={'FlowAmount_kg': 'FlowAmount'},
-                                   inplace=True)
+        # drop old amount and units; rename cols to match reference format
+        tri_national_totals = \
+            (tri_national_totals.drop(columns=['FlowAmount', 'Unit'])
+                                .rename(columns={'FlowAmount_kg': 'FlowAmount'}))
         inv = map_to_fedefl(inv)
         if inv is not None:
             validation_result = validate_inventory(inv, tri_national_totals,
@@ -264,8 +256,11 @@ def validate_national_totals(inv, TRIyear):
                     'Please run option B')
 
 
-def Generate_TRI_files_csv(TRIyear, Files):
-    """Generate TRI inventories from downloaded files."""
+def Generate_TRI_files_csv(TRIyear):
+    """
+    Generate TRI inventories from downloaded files.
+    :param TRIyear: str
+    """
     tri_required_fields = imp_fields(TRI_DATA_PATH.joinpath('TRI_required_fields.txt'))
     keys = imp_fields(TRI_DATA_PATH.joinpath('TRI_keys.txt'))
     values = list()
@@ -273,60 +268,40 @@ def Generate_TRI_files_csv(TRIyear, Files):
         start = 13 + 2*p
         end = start + 1
         values.append(concat_req_field(tri_required_fields[start: end + 1]))
-    # Create a dictionary that had the import fields for each release
-    # type to use in import process
+    # Create dict of required fields on import for each release type
     import_dict = dict_create(keys, values)
     # Build the TRI DataFrame
     tri = import_TRI_by_release_type(import_dict, TRIyear)
-    # drop NA for Amount, but leave in zeros
-    tri = tri.dropna(subset=['FlowAmount'])
-    tri = strip_coln_white_space(tri, 'Basis of Estimate')
+    tri = tri.dropna(subset=['FlowAmount'])  # drop nan amount rows
+    tri['Basis of Estimate'] = tri['Basis of Estimate'].str.strip()  # rm trailing spaces
     # Convert to float if there are errors - be careful with this line
     if tri['FlowAmount'].values.dtype != 'float64':
         tri['FlowAmount'] = pd.to_numeric(tri['FlowAmount'], errors='coerce')
     tri = tri[tri['FlowAmount'] != 0]
     # Import reliability scores for TRI
     tri_reliability_table = get_reliability_table_for_source('TRI')
-    tri = pd.merge(tri, tri_reliability_table, left_on='Basis of Estimate',
-                   right_on='Code', how='left')
+    tri = (pd.merge(tri, tri_reliability_table, left_on='Basis of Estimate',
+                    right_on='Code', how='left')
+             .drop(columns=['Basis of Estimate', 'Code']))
     tri['DQI Reliability Score'] = tri['DQI Reliability Score'].fillna(value=5)
-    tri.drop(['Basis of Estimate', 'Code'], axis=1, inplace=True)
     # Replace source info with Context
-    source_to_context = pd.read_csv(TRI_DATA_PATH
-                                    .joinpath('TRI_ReleaseType_to_Compartment.csv'))
+    source_to_context = pd.read_csv(TRI_DATA_PATH.joinpath(
+        'TRI_ReleaseType_to_Compartment.csv'))
     tri = pd.merge(tri, source_to_context, how='left')
     # Convert units to ref mass unit of kg
     tri['Amount_kg'] = 0.0
     tri = unit_convert(tri, 'Amount_kg', 'Unit', 'Pounds', lb_kg, 'FlowAmount')
     tri = unit_convert(tri, 'Amount_kg', 'Unit', 'Grams', g_kg, 'FlowAmount')
-    tri.drop(columns=['FlowAmount', 'Unit'], inplace=True)
-    # Rename cols to match reference format
-    tri.rename(columns={'Amount_kg': 'FlowAmount',
-                        'DQI Reliability Score': 'DataReliability'},
-               inplace=True)
-    tri.drop(columns=['ReleaseType'], inplace=True)
-    grouping_vars = ['FacilityID', 'FlowName', 'CAS', 'Compartment']
-    tri = aggregate(tri, grouping_vars)
+    tri = (tri.drop(columns=['FlowAmount', 'Unit', 'ReleaseType'])
+              .rename(columns={'Amount_kg': 'FlowAmount',       # to match reference format
+                               'DQI Reliability Score': 'DataReliability'}))
 
-    validate_national_totals(tri, TRIyear)
-
-    # FLOWS
-    flowsdf = tri[['FlowName', 'CAS', 'Compartment']
-                  ].drop_duplicates().reset_index(drop=True)
-    flowsdf.loc[:, 'FlowID'] = flowsdf['CAS']
-    store_inventory(flowsdf, 'TRI_' + TRIyear, 'flow')
-
-    # FLOW BY FACILITY
-    tri.drop(columns=['CAS'], inplace=True)
-    store_inventory(tri, 'TRI_' + TRIyear, 'flowbyfacility')
-
-    # FACILITY
-    # Import and handle TRI facility data
+    # FACILITY - import and handle TRI facility data
     import_facility = tri_required_fields[0:10]
-    tri_facility = pd.read_csv(OUTPUT_PATH.joinpath(f'US_1a_{TRIyear}.csv'),
-                               usecols=import_facility,
-                               low_memory=False)
-    tri_facility = tri_facility.drop_duplicates(ignore_index=True)
+    tri_facility = (pd.read_csv(OUTPUT_PATH.joinpath(f'US_1a_{TRIyear}.csv'),
+                                usecols=import_facility,
+                                low_memory=False)
+                      .drop_duplicates(ignore_index=True))
     # rename columns
     TRI_facility_name_crosswalk = {
         'TRIFID': 'FacilityID',
@@ -340,8 +315,33 @@ def Generate_TRI_files_csv(TRIyear, Files):
         'LATITUDE': 'Latitude',
         'LONGITUDE': 'Longitude',
         }
-    tri_facility.rename(columns=TRI_facility_name_crosswalk, inplace=True)
+    tri_facility = tri_facility.rename(columns=TRI_facility_name_crosswalk)
+    tri_facility = assign_secondary_context(tri_facility.copy(), int(TRIyear),
+                                            'urb', 'skip_concat')
+    tri_facility = pd.DataFrame(tri_facility) # TODO: ditch this at the end
     store_inventory(tri_facility, 'TRI_' + TRIyear, 'facility')
+
+    # merge & concat urban/rural into tri.Compartment
+    tri = tri.merge(tri_facility[['FacilityID', 'cmpt_urb']].drop_duplicates(),
+                    how='left', on='FacilityID')
+    tri.loc[tri['Compartment'] != 'air', 'cmpt_urb'] = 'unspecified'
+    tri = concat_compartment(tri, 'urb')     # TODO: run & check for Compartment
+
+    # then aggregate w/ expanded Compartment
+    grouping_vars = ['FacilityID', 'FlowName', 'CAS', 'Compartment']
+    tri = aggregate(tri, grouping_vars)
+
+    validate_national_totals(tri, TRIyear)
+
+    # FLOWS
+    flows = (tri[['FlowName', 'CAS', 'Compartment']].drop_duplicates()
+                                                    .reset_index(drop=True))
+    flows['FlowID'] = flows['CAS']
+    store_inventory(flows, 'TRI_' + TRIyear, 'flow')
+
+    # FLOW BY FACILITY
+    fbf = tri.drop(columns=['CAS'])
+    store_inventory(fbf, 'TRI_' + TRIyear, 'flowbyfacility')
 
 
 def generate_metadata(year, files, datatype='inventory'):

--- a/stewi/TRI.py
+++ b/stewi/TRI.py
@@ -319,14 +319,14 @@ def Generate_TRI_files_csv(TRIyear):
 
     tri_facility = assign_secondary_context(tri_facility, int(TRIyear), 'urb')
     store_inventory(tri_facility, 'TRI_' + TRIyear, 'facility')
+    
+    if 'cmpt_urb' in tri_facility.columns:  # given urban/rural assignment success
+        # merge & concat urban/rural into tri.Compartment before aggregation
+        tri = tri.merge(tri_facility[['FacilityID', 'cmpt_urb']].drop_duplicates(),
+                        how='left', on='FacilityID')
+        tri.loc[tri['Compartment'] != 'air', 'cmpt_urb'] = 'unspecified'
+        tri = concat_compartment(tri, 'urb')
 
-    # merge & concat urban/rural into tri.Compartment
-    tri = tri.merge(tri_facility[['FacilityID', 'cmpt_urb']].drop_duplicates(),
-                    how='left', on='FacilityID')
-    tri.loc[tri['Compartment'] != 'air', 'cmpt_urb'] = 'unspecified'
-    tri = concat_compartment(tri, 'urb')
-
-    # then aggregate w/ expanded Compartment
     grouping_vars = ['FacilityID', 'FlowName', 'CAS', 'Compartment']
     tri = aggregate(tri, grouping_vars)
 

--- a/stewi/TRI.py
+++ b/stewi/TRI.py
@@ -249,7 +249,7 @@ def validate_national_totals(inv, TRIyear):
         inv = map_to_fedefl(inv)
         if inv is not None:
             validation_result = validate_inventory(inv, tri_national_totals,
-                                                   group_by='flow', tolerance=5.0)
+                                                   group_by='compartment', tolerance=5.0)
             write_validation_result('TRI', TRIyear, validation_result)
     else:
         log.warning(f'validation file for TRI_{TRIyear} does not exist. '
@@ -319,7 +319,7 @@ def Generate_TRI_files_csv(TRIyear):
 
     tri_facility = assign_secondary_context(tri_facility, int(TRIyear), 'urb')
     store_inventory(tri_facility, 'TRI_' + TRIyear, 'facility')
-    
+
     if 'cmpt_urb' in tri_facility.columns:  # given urban/rural assignment success
         # merge & concat urban/rural into tri.Compartment before aggregation
         tri = tri.merge(tri_facility[['FacilityID', 'cmpt_urb']].drop_duplicates(),

--- a/stewi/TRI.py
+++ b/stewi/TRI.py
@@ -320,11 +320,10 @@ def Generate_TRI_files_csv(TRIyear):
     tri_facility = assign_secondary_context(tri_facility, int(TRIyear), 'urb')
     store_inventory(tri_facility, 'TRI_' + TRIyear, 'facility')
 
-    if 'cmpt_urb' in tri_facility.columns:  # given urban/rural assignment success
+    if 'UrbanRural' in tri_facility.columns:  # given urban/rural assignment success
         # merge & concat urban/rural into tri.Compartment before aggregation
-        tri = tri.merge(tri_facility[['FacilityID', 'cmpt_urb']].drop_duplicates(),
+        tri = tri.merge(tri_facility[['FacilityID', 'UrbanRural']].drop_duplicates(),
                         how='left', on='FacilityID')
-        tri.loc[tri['Compartment'] != 'air', 'cmpt_urb'] = 'unspecified'
         tri = concat_compartment(tri, True, 'urb')  # passes has_geo_pkgs=True
 
     grouping_vars = ['FacilityID', 'FlowName', 'CAS', 'Compartment']

--- a/stewi/TRI.py
+++ b/stewi/TRI.py
@@ -316,16 +316,15 @@ def Generate_TRI_files_csv(TRIyear):
         'LONGITUDE': 'Longitude',
         }
     tri_facility = tri_facility.rename(columns=TRI_facility_name_crosswalk)
-    tri_facility = assign_secondary_context(tri_facility.copy(), int(TRIyear),
-                                            'urb', 'skip_concat')
-    tri_facility = pd.DataFrame(tri_facility) # TODO: ditch this at the end
+
+    tri_facility = assign_secondary_context(tri_facility, int(TRIyear), 'urb')
     store_inventory(tri_facility, 'TRI_' + TRIyear, 'facility')
 
     # merge & concat urban/rural into tri.Compartment
     tri = tri.merge(tri_facility[['FacilityID', 'cmpt_urb']].drop_duplicates(),
                     how='left', on='FacilityID')
     tri.loc[tri['Compartment'] != 'air', 'cmpt_urb'] = 'unspecified'
-    tri = concat_compartment(tri, 'urb')     # TODO: run & check for Compartment
+    tri = concat_compartment(tri, 'urb')
 
     # then aggregate w/ expanded Compartment
     grouping_vars = ['FacilityID', 'FlowName', 'CAS', 'Compartment']

--- a/stewi/TRI.py
+++ b/stewi/TRI.py
@@ -427,7 +427,7 @@ def main(**kwargs):
 
         elif kwargs['Option'] == 'C':
             log.info(f'generating TRI inventory from files for {year}')
-            Generate_TRI_files_csv(year, files)
+            Generate_TRI_files_csv(year)
             generate_metadata(year, files, datatype='inventory')
 
 

--- a/stewi/TRI.py
+++ b/stewi/TRI.py
@@ -325,7 +325,7 @@ def Generate_TRI_files_csv(TRIyear):
         tri = tri.merge(tri_facility[['FacilityID', 'cmpt_urb']].drop_duplicates(),
                         how='left', on='FacilityID')
         tri.loc[tri['Compartment'] != 'air', 'cmpt_urb'] = 'unspecified'
-        tri = concat_compartment(tri, 'urb')
+        tri = concat_compartment(tri, True, 'urb')  # passes has_geo_pkgs=True
 
     grouping_vars = ['FacilityID', 'FlowName', 'CAS', 'Compartment']
     tri = aggregate(tri, grouping_vars)

--- a/stewi/egrid.py
+++ b/stewi/egrid.py
@@ -301,7 +301,7 @@ def validate_eGRID(year, flowbyfac):
     # drop old unit
     egrid_national_totals.drop('Unit', axis=1, inplace=True)
     validation_result = validate_inventory(flowbyfac, egrid_national_totals,
-                                           group_by='flow', tolerance=5.0)
+                                           group_by='compartment', tolerance=5.0)
     write_validation_result('eGRID', year, validation_result)
 
 

--- a/stewi/formats.py
+++ b/stewi/formats.py
@@ -78,6 +78,7 @@ facility_fields = {'FacilityID': [{'dtype': 'str'}, {'required': True}],
                    'County': [{'dtype': 'str'}, {'required': False}],
                    'NAICS': [{'dtype': 'str'}, {'required': False}],
                    'SIC': [{'dtype': 'str'}, {'required': False}],
+                   'UrbanRural': [{'dtype': 'str'}, {'required': False}],
                    }
 
 flowbyprocess_fields = {'FacilityID': [{'dtype': 'str'}, {'required': True}],

--- a/stewi/globals.py
+++ b/stewi/globals.py
@@ -231,7 +231,7 @@ def compile_source_metadata(sourcefile, config, year):
 
 
 def remove_line_breaks(df, headers_only=True):
-    df.columns = df.columns.str.replace('\r|\n', ' ')
+    df.columns = df.columns.str.replace('\r|\n', ' ', regex=True)
     if not headers_only:
         df = df.replace('\r\n', ' ').replace('\n', ' ')
     return df

--- a/stewi/globals.py
+++ b/stewi/globals.py
@@ -382,27 +382,20 @@ def assign_secondary_context(df, year, *args):
     from esupy import context_secondary as e_c_s
     df = e_c_s.main(df, year, *args)  # if e_c_s.has_geo_pkgs == False, returns unaltered df
     if 'concat' in args:
-        if 'urb' in args and e_c_s.has_geo_pkgs==False:
-            pass    # prevent concatenation when unaltered df is returned
-        else:
-            df = concat_compartment(df, *args)
+        df = concat_compartment(df, e_c_s.has_geo_pkgs, *args)
     return df
 
-def concat_compartment(df, *cmpts):
+def concat_compartment(df, has_geo_pkgs, *cmpts):
     """
-	Concatenate primary & secondary compartment df cols by into a single col
-    context 'Compartment' column
+	Concatenate primary & secondary compartment cols sequentially. If both
+    'urb' and 'rh' are passed, return Compartment w/ order 'primary/urb/rh'.
 	:param df: pd.DataFrame, including compartment cols
+    :param has_geo_pkgs: bool, created via esupy context_secondary import
     :cmpts: str, compartment string code(s) {'urb', 'rh'}
     """
-    if 'urb' in cmpts and 'rh' in cmpts:
-        df['Compartment'] = df['Compartment'] + '/' + df['cmpt_urb'] + '/' + df['cmpt_rh']
-    elif 'urb' in cmpts:
+    if 'urb' in cmpts and has_geo_pkgs:
         df['Compartment'] = df['Compartment'] + '/' + df['cmpt_urb']
-    elif 'rh' in cmpts:
+    if 'rh' in cmpts:
         df['Compartment'] = df['Compartment'] + '/' + df['cmpt_rh']
-    else:
-        log.warning('No valid secondary compartment code args {urb, rh} supplied')
-        return None
     df['Compartment'] = df['Compartment'].str.replace('/unspecified','')
     return df

--- a/stewi/globals.py
+++ b/stewi/globals.py
@@ -16,7 +16,6 @@ from pathlib import Path
 import pandas as pd
 import yaml
 
-from esupy import context_secondary as e_c_s
 from esupy.processed_data_mgmt import Paths, FileMeta,\
     load_preprocessed_output, remove_extra_files,\
     write_df_to_file, write_metadata_to_file,\
@@ -380,9 +379,13 @@ def assign_secondary_context(df, year, *args):
     :param year: int, data year
     :param args: str, flag(s) for compartment assignment + skip_concat option
     """
-    df = e_c_s.main(df, year, *args)
+    from esupy import context_secondary as e_c_s
+    df = e_c_s.main(df, year, *args)  # if e_c_s.has_geo_pkgs == False, returns unaltered df
     if 'concat' in args:
-        df = concat_compartment(df, *args)
+        if 'urb' in args and e_c_s.has_geo_pkgs==False:
+            pass    # prevent concatenation when unaltered df is returned
+        else:
+            df = concat_compartment(df, *args)
     return df
 
 def concat_compartment(df, *cmpts):

--- a/stewi/globals.py
+++ b/stewi/globals.py
@@ -381,6 +381,8 @@ def assign_secondary_context(df, year, *args):
     """
     from esupy import context_secondary as e_c_s
     df = e_c_s.main(df, year, *args)  # if e_c_s.has_geo_pkgs == False, returns unaltered df
+    if 'cmpt_urb' in df.columns:  # rename before storage w/ facilities
+        df = df.rename(columns={'cmpt_urb': 'UrbanRural'})
     if 'concat' in args:
         df = concat_compartment(df, e_c_s.has_geo_pkgs, *args)
     return df
@@ -394,7 +396,7 @@ def concat_compartment(df, has_geo_pkgs, *cmpts):
     :cmpts: str, compartment string code(s) {'urb', 'rh'}
     """
     if 'urb' in cmpts and has_geo_pkgs:
-        df['Compartment'] = df['Compartment'] + '/' + df['cmpt_urb']
+        df['Compartment'] = df['Compartment'] + '/' + df['UrbanRural']
     if 'rh' in cmpts:
         df['Compartment'] = df['Compartment'] + '/' + df['cmpt_rh']
     df['Compartment'] = df['Compartment'].str.replace('/unspecified','')

--- a/stewi/validate.py
+++ b/stewi/validate.py
@@ -35,8 +35,10 @@ def validate_inventory(inventory_df, reference_df, group_by='flow',
         reference_df['FlowAmount'] = pd.to_numeric(reference_df['FlowAmount'])
     if group_by == 'flow':
         group_by_columns = ['FlowName']
-        if 'Compartment' in inventory_df.keys():
-            group_by_columns += ['Compartment']
+    elif group_by == 'compartment':
+        group_by_columns = ['FlowName', 'PrimaryCompartment']
+        reference_df['PrimaryCompartment'] = reference_df['Compartment']
+        inventory_df['PrimaryCompartment'] = inventory_df['Compartment'].str.split('/').str[0]
     elif group_by == 'state':
         group_by_columns = ['State']
     elif group_by == 'facility':

--- a/stewicombo/__init__.py
+++ b/stewicombo/__init__.py
@@ -8,7 +8,7 @@ Public API for stewicombo. Functions to combine inventory data
 import facilitymatcher
 from stewicombo.overlaphandler import aggregate_and_remove_overlap
 from stewicombo.globals import get_id_before_underscore,\
-    getInventoriesforFacilityMatches, filter_by_compartment,\
+    getInventoriesforFacilityMatches, filter_by_primary_compartment,\
     addChemicalMatches, addBaseInventoryIDs, storeCombinedInventory,\
     write_stewicombo_metadata, compile_metadata, getCombinedInventory,\
     download_stewicombo_from_remote
@@ -38,7 +38,7 @@ def combineFullInventories(inventory_dict, filter_for_LCI=True,
     if len(inventories) == 0:
         return None
     if compartments is not None:
-        inventories = filter_by_compartment(inventories, compartments)
+        inventories = filter_by_primary_compartment(inventories, compartments)
 
     inventories = addChemicalMatches(inventories)
 

--- a/stewicombo/globals.py
+++ b/stewicombo/globals.py
@@ -240,7 +240,12 @@ def compile_metadata(inventory_dict):
     return inventory_meta
 
 
-def filter_by_compartment(df, compartments):
-    #TODO disaggregate compartments to include all children
-    df = df[df['Compartment'].isin(compartments)]
+def filter_by_primary_compartment(df, compartments):
+    """
+    Filter df to keep all entries with primary Compartment values in a given
+    list, chosen from {'water', 'air', 'land'}
+    :param df: pd.DataFrame
+    :param compartments: list, compartments to include
+    """
+    df = df[df['Compartment'].str.startswith(tuple(compartments))]
     return df

--- a/stewicombo/overlaphandler.py
+++ b/stewicombo/overlaphandler.py
@@ -3,6 +3,7 @@ from stewicombo.globals import log, LOOKUP_FIELDS, SOURCE_COL,INCLUDE_ORIGINAL,\
     INVENTORY_PREFERENCE_BY_COMPARTMENT, KEEP_ALL_DUPLICATES, FORCE_COLUMN_TYPES,\
     KEEP_ROW_WITHOUT_DUPS, COL_FUNC_PAIRS, COL_FUNC_DEFAULT, COMPARTMENT_COL,\
     VOC_srs
+from stewi.globals import aggregate
 
 if "LOOKUP_FIELDS" not in locals() and LOOKUP_FIELDS:
     raise ValueError("Not sure which fields to lookup in each row. "
@@ -50,6 +51,12 @@ def get_by_preference(group):
 
 
 def aggregate_and_remove_overlap(df):
+
+    # Temporarily set all compartments to the primary compartment
+    # until overlap handler is updated
+    df['Compartment'] = df['Compartment'].str.partition('/')[0]
+    df = aggregate(df)
+
     if not INCLUDE_ORIGINAL and not KEEP_ALL_DUPLICATES:
         raise ValueError("Cannot have both INCLUDE_ORIGINAL and "
                          "KEEP_REPEATED_DUPLICATES fields as False")


### PR DESCRIPTION
Assign release height and urban/rural secondary compartments to TRI and NEI facilities and associated flows using esupy's new [context_secondary](https://github.com/USEPA/esupy/blob/develop/esupy/context_secondary.py) module, handled via a new `stewi.globals` function. Release height relies on simple binning and labeling by facility stack height, and only applies to emissions with a primary `air` compartment. The urban/rural classification uses Census Urban Area and Cluster (UAC) shapefiles to identify whether or not a facility lies within an urban area polygon, and applies to emissions across all primary compartments.

The new `stewi.globals.assign_secondary_context` function coordinates this assignment flexibly using `*args` string codes to perform one or both assignments. Including the 'concat' string argument can then invoke `concat_compartment` (as in `NEI.py`), or it can be called separately (see `TRI.py`).

Additionally, safeguards and error handling are included to check for the geospatial dependencies (`GeoPandas`, `Shapely`, etc.)—which can be difficult to install on certain platforms—before attempting the urban/rural assignment. The resulting TRI and NEI metadata files reflect whether or not the urban/rural classification was able to proceed and store an `UrbanRural` field in the output.