### PR TITLE
resolves "variable called before assignment" error when TRI preferred over DMR in stewicombo

### DIFF
--- a/stewi/DMR.py
+++ b/stewi/DMR.py
@@ -456,6 +456,8 @@ def remove_nutrient_overlap_TRI(df, preference):
     # for facilities where the FRS and compartment match
     if preference == 'DMR':
         keep_list = dmr_list
+    else:
+        keep_list = tri_list
 
     df_nutrients = df.loc[((df['FlowName'].isin(combined_list)) &
                            (df['Compartment'] == 'water'))]


### PR DESCRIPTION
This package is a life saver, y'all. Thank you.

After setting `"water": ["TRI", "DMR"],` in `INVENTORY_PREFERENCE_BY_COMPARTMENT`, and running 
```
all = combineFullInventories({'TRI':2014, 'NEI':2014, 'DMR':2014}, filter_for_LCI = False)
```
(Ubuntu 20.04, Python 3.10.5, StEWI 1.0.5)

I received an error stating that the `keep_list` variable was being called before assignment. That error appears to be resolved by this small change.

Sorry I don't have the exact error text. As it stands, you actually have to reinstall StEWI in order to modify `INVENTORY_PREFERENCE_BY_COMPARTMENT` in a way that affects package behavior. Was that intended?