### PR TITLE
egrid bux fix

### DIFF
--- a/stewi/egrid.py
+++ b/stewi/egrid.py
@@ -203,6 +203,7 @@ def generate_eGRID_files(year):
                                                         'ReliabilitySource',
                                                         'FlowAmount']))
                                       ).apply(pd.Series.explode).reset_index()
+    unit_egrid['FlowAmount'] = pd.to_numeric(unit_egrid['FlowAmount'])
 
     dq_mapping = pd.read_csv(eGRID_DATA_DIR
                              .joinpath('eGRID_unit_level_reliability_scores.csv'))


### PR DESCRIPTION
ensure egird columns are numeric to avoid `ZeroDivisionError: float division by zero`