### PR TITLE
New getAllInventoriesandYears method

### DIFF
--- a/stewi/__init__.py
+++ b/stewi/__init__.py
@@ -3,7 +3,7 @@
 # coding=utf-8
 """
 Public API for stewi. Functions to return inventory data for a single
-inventory in standard formats
+inventory in standard formats.
 """
 
 
@@ -11,12 +11,44 @@ from esupy.processed_data_mgmt import read_source_metadata
 from stewi.globals import log, add_missing_fields,\
     WRITE_FORMAT, read_inventory, paths,\
     set_stewi_meta, aggregate
+from stewi.globals import STEWI_DATA_VINTAGES
+from stewi.globals import linear_search
 from stewi.filter import apply_filters_to_inventory, filter_config
 from stewi.formats import StewiFormat, ensure_format
 
 
+def getAllInventoriesandYears(year=None):
+    """Return inventory year(s) of interest.
+
+    If no year is given, the full list of years are returned for each inventory
+    otherwise, only the most recent year is provided for each inventory (i.e.,
+    with vintage the same or older than the given year).
+
+    :param year: An integer year of interest, defaults to None
+    :type year: int, optional
+    :return: A dictionary of inventory names (key) and list or int of year(s)
+    :rtype: dict
+    """
+    r_dict = {}
+    if year is None:
+        # Don't give user access to global var: copy it!
+        for k,v in STEWI_DATA_VINTAGES.items():
+            r_dict[k] = v
+    else:
+        for key in STEWI_DATA_VINTAGES.keys():
+            avail_years = STEWI_DATA_VINTAGES[key]
+            y_idx = linear_search(avail_years, year)
+            if y_idx != -1:
+                r_dict[key] = STEWI_DATA_VINTAGES[key][y_idx]
+    return r_dict
+
+
 def getAvailableInventoriesandYears(stewiformat='flowbyfacility'):
     """Get available inventories and years for a given output format.
+
+    Note these inventories and years are based on the data downloaded by
+    the user. For the whole list of available inventories, see
+    :func:`getAllInventoriesandYears`.
 
     :param stewiformat: str e.g. 'flowbyfacility'
     :return: existing_inventories dictionary of inventories like:

--- a/stewi/globals.py
+++ b/stewi/globals.py
@@ -2,7 +2,7 @@
 # !/usr/bin/env python3
 # coding=utf-8
 """
-Supporting variables and functions used in stewi
+Supporting variables and functions used in stewi.
 """
 
 import json
@@ -70,6 +70,16 @@ inventory_single_compartments = {"NEI": "air",
                                  "GHGRP": "air",
                                  "DMR": "water"}
 
+STEWI_DATA_VINTAGES = {
+    'DMR': [x for x in range(2011, 2023, 1)],
+    'GHGRP': [x for x in range(2011, 2023, 1)],
+    'eGRID': [2014, 2016, 2018, 2019, 2020, 2021],
+    'NEI': [2011, 2014, 2017, 2020],
+    'RCRAInfo': [x for x in range(2011, 2023, 2)],
+    'TRI': [x for x in range(2011, 2023, 1)],
+}
+'''A dictionary of StEWI inventories and their available vintages.'''
+
 
 def set_stewi_meta(file_name, stewiformat=''):
     """Create a class of esupy FileMeta with stewiformat assigned as category."""
@@ -112,6 +122,33 @@ def aggregate(df, grouping_vars=None):
     df_agg = df_agg[df_agg['FlowAmount'] > 0]
     df_agg = df_agg[df_agg['FlowAmount'].notna()]
     return df_agg
+
+
+def linear_search(lst, target):
+    """Backwards search a list for index less than or equal to a given value.
+
+    :param lst: (list) A list of numerically sorted data (lowest to highest).
+    :param target : (int, float) A target value (e.g., year).
+    :return: (int)
+        The index of the search list associated with the value equal to or
+        less than the target, else -1 for a target out-of-range (i.e., smaller than the smallest entry in the list).
+
+    :Example:
+
+    >>> NEI_YEARS = [2011, 2014, 2017, 2020]
+    >>> linear_search(NEI_YEARS, 2020)
+    3
+    >>> linear_search(NEI_YEARS, 2019)
+    2
+    >>> linear_search(NEI_YEARS, 2018)
+    2
+    >>> linear_search(NEI_YEARS, 2010)
+    -1
+    """
+    for i in range(len(lst) - 1, -1, -1):
+        if lst[i] <= target:
+            return i
+    return -1
 
 
 def unit_convert(df, coln1, coln2, unit, conversion_factor, coln3):


### PR DESCRIPTION
Addresses #150.
- Create new global dictionary, STEWI_DATA_VINTAGES, which needs to be manually updated when new standardized inventories become available. 
- Create new global method, linear_search, for reverse searching a list and pulling the index of the value up to but not greater than a given value. 
- Create new init method, getAllInventoriesandYears, to companion with getAvailableInventoriesandYears; the former returns the STEWI_DATA_VINTAGES dictionary if no year is given; otherwise, uses the linear search to get the most appropriate inventory years for a given year.